### PR TITLE
Correct font install instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ pip install --user powerline-status
 
   ```
 git clone https://github.com/powerline/fonts
-cd powerline
+cd fonts
 ./install.sh
   ```
 


### PR DESCRIPTION
The cloned repository is `fonts` and not `powerline`. Hence, the command should be `cd fonts`.