### PR TITLE
Fix step-by-step installation heading

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Two things for lovers of the [Sublime Text Theme](https://github.com/wesbos/coba
 
 They work well together! You will need to install the patched powerline font as well: <https://github.com/powerline/fonts>
 
-####Step-by-step installation
+#### Step-by-step installation
 1. Drop the `cobalt2.zsh-theme` file in to the `~/.oh-my-zsh/themes/` directory.
 2. Open up your ZSH preferences at `~/.zshrc` and change the theme variable to `ZSH_THEME="cobalt2"`.
 


### PR DESCRIPTION
The text doesn't render as a H4 due to incorrect usage of the heading tag in markdown. This PR fixes that by introducing a space between the hashtags and the following text.