### PR TITLE
add git hide status

### DIFF
--- a/cobalt2.zsh-theme
+++ b/cobalt2.zsh-theme
@@ -55,17 +55,19 @@ prompt_context() {
 
 # Git: branch/detached head, dirty status
 prompt_git() {
-  local ref dirty
-  if $(git rev-parse --is-inside-work-tree >/dev/null 2>&1); then
-    ZSH_THEME_GIT_PROMPT_DIRTY='±'
-    dirty=$(parse_git_dirty)
-    ref=$(git symbolic-ref HEAD 2> /dev/null) || ref="➦ $(git show-ref --head -s --abbrev |head -n1 2> /dev/null)"
-    if [[ -n $dirty ]]; then
-      prompt_segment yellow black
-    else
-      prompt_segment green black
+  if [[ "$(git config --get oh-my-zsh.hide-status)" != "1" ]]; then
+    local ref dirty
+    if $(git rev-parse --is-inside-work-tree >/dev/null 2>&1); then
+      ZSH_THEME_GIT_PROMPT_DIRTY='±'
+      dirty=$(parse_git_dirty)
+      ref=$(git symbolic-ref HEAD 2> /dev/null) || ref="➦ $(git show-ref --head -s --abbrev |head -n1 2> /dev/null)"
+      if [[ -n $dirty ]]; then
+        prompt_segment yellow black
+      else
+        prompt_segment green black
+      fi
+      echo -n "${ref/refs\/heads\// }$dirty"
     fi
-    echo -n "${ref/refs\/heads\// }$dirty"
   fi
 }
 


### PR DESCRIPTION
ZSH will not show git prompt in repository's directory after entering the following command:
`git config oh-my-zsh.hide-status 1`

