### PR TITLE
Allow prompt symbol customization

### DIFF
--- a/cobalt2.zsh-theme
+++ b/cobalt2.zsh-theme
@@ -11,6 +11,7 @@
 
 CURRENT_BG='NONE'
 SEGMENT_SEPARATOR=''
+USER_ICON=${COBALT_2_ICON:-'✝'}
 
 # Begin a segment
 # Takes two arguments, background and foreground. Both can be omitted,
@@ -49,7 +50,7 @@ prompt_context() {
   local user=`whoami`
 
   if [[ "$user" != "$DEFAULT_USER" || -n "$SSH_CLIENT" ]]; then
-    prompt_segment black default "%(!.%{%F{yellow}%}.)✝"
+    prompt_segment black default "%(!.%{%F{yellow}%}.)$USER_ICON"
   fi
 }
 

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,14 @@ Two things for lovers of the [Sublime Text Theme](https://github.com/wesbos/coba
 
 They work well together! You will need to install the patched powerline font as well: <https://github.com/powerline/fonts>
 
+## Customizing the Icon
+
+By default the `✝`-icon will be displayed in the prompt. However, you can customize this by exporting a symbol in `COBALT_2_ICON` like so:
+
+```bash
+export COBALT_2_ICON=🦊
+```
+
 #### Step-by-step installation
 1. Drop the `cobalt2.zsh-theme` file in to the `~/.oh-my-zsh/themes/` directory.
 2. Open up your ZSH preferences at `~/.zshrc` and change the theme variable to `ZSH_THEME=cobalt2`.


### PR DESCRIPTION
This adds the capability to override the default prompt icon `✝` via the environment variable `COBALT_2_ICON` (as suggested by @wesbos during a Syntax episode).