### PR TITLE
Show current Node-verison in prompt

### DIFF
--- a/cobalt2.zsh-theme
+++ b/cobalt2.zsh-theme
@@ -75,6 +75,14 @@ prompt_dir() {
   # prompt_segment blue black "…${PWD: -30}"
 }
 
+# Node:
+# - Display Node version in use
+prompt_node() {
+  if which node &> /dev/null; then
+    prompt_segment black green "$(node -v)"
+  fi
+}
+
 # Status:
 # - was there an error
 # - am I root
@@ -93,6 +101,7 @@ prompt_status() {
 build_prompt() {
   RETVAL=$?
   prompt_status
+  prompt_node
   prompt_context
   prompt_dir
   prompt_git


### PR DESCRIPTION
Love the theme and have been using it for a while now! 💯 👏 

I sometimes switch my node-version with NVM to test or debug things and wanted quickly to see what version I am using - so I added the node version to the prompt.

Feel free to add it if you feel like it makes sense as part of the theme 😄 

![18_08_19__18_03](https://user-images.githubusercontent.com/19314055/63227039-7ae35800-c1e2-11e9-8698-dd04c1ed3b9d.png)
